### PR TITLE
fix(links): replace http:// links with https://

### DIFF
--- a/src/pages/_home/home.html
+++ b/src/pages/_home/home.html
@@ -13,7 +13,7 @@
     if you checked out the <a href="https://github.com/yannbf/ionic2-components">repository</a> and contribute!
   </p>
   <p>
-    Also, the best way to understand the ionic framework is by reading the <a href="http://ionicframework.com/docs/v2">docs</a>,
+    Also, the best way to understand the ionic framework is by reading the <a href="https://ionicframework.com/docs/v2">docs</a>,
     which are really great.
   </p>
   <button class="pop-in" ion-button secondary menuToggle>Toggle Menu</button>
@@ -23,7 +23,7 @@
   <div class="content">
     The world is your oyster.
     <p>
-      If you get lost, the <a href="http://ionicframework.com/docs/v2">docs</a> will be your guide.
+      If you get lost, the <a href="https://ionicframework.com/docs/v2">docs</a> will be your guide.
     </p>
   </div>
 </sliding-drawer>-->

--- a/src/pages/accordion-list/accordion-list.ts
+++ b/src/pages/accordion-list/accordion-list.ts
@@ -11,22 +11,22 @@ export class AccordionListPage {
     {
       name: 'Angra dos Reis, Brazil',
       description: 'Brazil’s visa waiver during the Olympics was a success for one big reason: it encouraged travel beyond the big cities. The tourism board hopes to bring back the waiver, and if you’re planning to take advantage, save time to visit Angra dos Reis, between Rio and São Paulo. This popular Brazilian vacation area is where cariocas go to escape the crowds. “It’s where many of the country’s elite have their beach villas,” says Martin Frankenberg of Matuete, who has access to several of these glamorous rentals. Big changes are coming to the region. In May, Brazilian chain Fasano will open a long-awaited 54-suite hotel in a complex that includes a marina, golf course, restaurants, and a spa. The design is striking, with elevated wooden buildings that look like they’re floating, all with open-air terraces and views of the forest and sea. And the government recently pledged $8 million to improve the infrastructure on Ilha Grande—an island that’s so popular that they’ve had to impose a daily limit on visitors. —Stephanie Wu',
-      imageUrl: 'http://cdn-image.travelandleisure.com/sites/default/files/styles/964x524/public/1479915553/angra-dos-reis-brazil-WTG2017.jpg?itok=damBsB9G',
+      imageUrl: 'https://cdn-image.travelandleisure.com/sites/default/files/styles/964x524/public/1479915553/angra-dos-reis-brazil-WTG2017.jpg?itok=damBsB9G',
     },
     {
       name: 'Belfast, Northern Ireland',
       description: 'With a growing array of open-air bars, arts venues, and restaurants, Belfast is quickly becoming an attractive destination for travelers. Stay at the design-forward Bullitt Hotel (inspired by the Steve McQueen film), which opened in October with casual, well-appointed rooms and complimentary grab-and-go breakfast granola. Check out arts organization Seedhead, which runs street-art tours and hosts pop-up cabarets around the city. The Michelin-starred OX and EIPIC lead the fine-dining pack, but also visit Permit Room, with its internationally inspired breakfast and locally roasted coffee. Noteworthy new nightlife spots include the Muddlers Club, a stylish restaurant and cocktail bar in the trendy Cathedral Quarter, and Vandal, a graffiti-adorned pizza place that turns into a late-night club, on the top floor of a 17th-century pub.—Nell McShane Wulfhart',
-      imageUrl: 'http://cdn-image.travelandleisure.com/sites/default/files/styles/964x524/public/1480711606/belfast-city-hall-northern-ireland-WTG2017.jpg?itok=mCqumH31',
+      imageUrl: 'https://cdn-image.travelandleisure.com/sites/default/files/styles/964x524/public/1480711606/belfast-city-hall-northern-ireland-WTG2017.jpg?itok=mCqumH31',
     },
     {
       name: 'Belgrade, Serbia',
       description: 'Since the end of the Yugoslav wars, Belgrade has attracted steady investment—its graffiti-covered neighborhoods are now full of restaurants and bars. You’ll find hearty platters of ćevapi—smoky sausages without casing—and stuffed somborka peppers at Sokače, paprika-laden kebabs at Tri Šešira, and pan-Latin tapas at Toro. But the biggest draw is the growing craft-beer scene (the city has 37 breweries). Don’t miss the Kabinet Supernova IPA at Prohibicija in the bar-filled Savamala district, as well as Kas’s full-bodied pale ales and Salto’s IPA at Bajloni, set in a 100-year-old brewery space in Cetinjska. —Govind Dhar',
-      imageUrl: 'http://cdn-image.travelandleisure.com/sites/default/files/styles/964x524/public/1479487289/belgrade-serbia-fortress-WTG2017.jpg?itok=rw8c4Esh',
+      imageUrl: 'https://cdn-image.travelandleisure.com/sites/default/files/styles/964x524/public/1479487289/belgrade-serbia-fortress-WTG2017.jpg?itok=rw8c4Esh',
     },
     {
       name: 'Bermuda',
       description: 'After being hit hard by the financial crisis, Bermuda is shaking itself out of stagnation and attracting a new generation of travelers. In 2014, the island won a bid to host the 35th America’s Cup, the high-profile international sailing race, which takes place this June. The promise of a flood of wealthy visitors—and a loosening of restrictions on foreign investment—has sparked a spate of development. Big news is the $100 million overhaul of the Hamilton Princess & Beach Club, the island’s 132-year-old grande dame, whose revamped rooms have a fresh, contemporary look. The hotel has also added a stellar art collection, a spa, and a restaurant serving locally sourced fare from James Beard Award–winning chef Marcus Samuelsson. Elsewhere on the island, a St. Regis, a lavish Ritz-Carlton Reserve, and the Ariel Sands resort (backed by actors Michael Douglas and Catherine Zeta-Jones) are in the works. —Paola Singer',
-      imageUrl: 'http://cdn-image.travelandleisure.com/sites/default/files/styles/964x524/public/1479915553/hamilton-princess-bermuda-WTG2017.jpg?itok=E4sFyZFn',
+      imageUrl: 'https://cdn-image.travelandleisure.com/sites/default/files/styles/964x524/public/1479915553/hamilton-princess-bermuda-WTG2017.jpg?itok=E4sFyZFn',
     }
   ]
   constructor(public navCtrl: NavController) { }

--- a/src/pages/login/login-background-video/login-background-video.html
+++ b/src/pages/login/login-background-video/login-background-video.html
@@ -9,7 +9,7 @@
     <button ion-button class="login-button google" (click)="goToLogin()">Login</button>
     <button ion-button class="login-button" color="dark" (click)="goToSignup()">Create account</button>
   </div>
-  <video #player playsinline autoplay muted loop poster="assets/video-cover.jpg" id="bgvid">
+  <video #player playsinline autoplay muted loop poster="assets/video/video-cover.jpg" id="bgvid">
     <source src="assets/video/background-480.mp4" type="video/mp4"> Your browser does not support the video tag.
   </video>
 </ion-content>

--- a/src/pages/popup-modal/hint-modal/hint-modal.html
+++ b/src/pages/popup-modal/hint-modal/hint-modal.html
@@ -3,8 +3,8 @@
     <ion-title>Tip for you</ion-title>
     <ion-buttons end>
       <button ion-button icon-only>
-      <ion-icon name='bulb'></ion-icon>
-    </button>
+        <ion-icon name='bulb'></ion-icon>
+      </button>
     </ion-buttons>
   </ion-navbar>
 </ion-header>
@@ -23,7 +23,9 @@
   <p>Selfies normcore four dollar toast four loko listicle artisan. Hoodie Marfa authentic, wayfarers church-key tofu Banksy
     pop-up Kickstarter Brooklyn heirloom swag synth. Echo Park cray synth mixtape. Tofu gastropub squid readymade, trust
     fund Wes Anderson DIY PBR 8-bit try-hard +1 Shoreditch lo-fi tote bag.</p>
-  <p><img src="http://unsplash.it/600/300" alt="" /></p>
+  <p>
+    <img src="https://unsplash.it/600/300" alt="" />
+  </p>
   <p>Mumblecore cred selfies fingerstache. Tousled skateboard plaid lo-fi shabby chic salvia, swag Odd Future Etsy art party
     Austin cronut. Crucifix whatever Pinterest food truck, pickled viral cray 90's DIY chambray keffiyeh biodiesel Vice blog.
     Cred meh yr tofu.</p>
@@ -33,6 +35,5 @@
 </ion-content>
 <ion-footer>
   <button ion-button full color="danger" (click)="dismiss()">Okay
-      </button>
+  </button>
 </ion-footer>
-

--- a/src/pages/profile/profile-one/profile-one.html
+++ b/src/pages/profile/profile-one/profile-one.html
@@ -10,8 +10,8 @@
       <img id="profile-image" src="assets/img/profile/profile-2.jpg">
       <h3 id="profile-name">John</h3>
       <span id="profile-description">Traveler, geek and animal lover.</span>
-      <p>Follow my <a href="http://twitter.com/ionicframework">@facebook</a> and
-        <a href="http://twitter.com/driftyco">@twitter</a> accounts.</p>
+      <p>Follow my <a href="https://twitter.com/ionicframework">@facebook</a> and
+        <a href="https://twitter.com/driftyco">@twitter</a> accounts.</p>
     </div>
     <ion-list>
       <ion-item *ngFor="let post of posts">

--- a/src/pages/profile/profile-settings/profile-settings.ts
+++ b/src/pages/profile/profile-settings/profile-settings.ts
@@ -14,7 +14,7 @@ export class ProfileSettingsPage {
   profilePicture: string;
   profileRef: any;
   errorMessage: any;
-  placeholderPicture = 'http://api.adorable.io/avatar/200/bob';
+  placeholderPicture = 'https://api.adorable.io/avatar/200/bob';
 
   enableNotifications = true;
   language: any;

--- a/src/pages/profile/profile-two/profile-two.html
+++ b/src/pages/profile/profile-two/profile-two.html
@@ -7,7 +7,7 @@
   <div class="header">
     <h1>Richard Karsten</h1>
     <h2>Frontend</h2>
-    <img src="http://clikr.de/wp-content/uploads/2015/02/richard-150x150.jpg" class="profile" />
+    <img src="https://clikr.de/wp-content/uploads/2015/02/richard-150x150.jpg" class="profile" />
   </div>
   <div class="content">
     <h3>about me</h3>

--- a/src/pages/slide/slide-carousel/slide-carousel.ts
+++ b/src/pages/slide/slide-carousel/slide-carousel.ts
@@ -23,8 +23,8 @@ export class SlideCarouselPage {
   city1: any = {
     name: 'Paris',
     favorited: false,
-    image: 'http://bit.ly/2aXzczV',
-    authorPic: 'http://bit.ly/2dMCa9y',
+    image: 'https://bit.ly/2aXzczV',
+    authorPic: 'https://bit.ly/2dMCa9y',
     favoriteCount: 10,
     comments: [1, 2, 3],
   };
@@ -32,8 +32,8 @@ export class SlideCarouselPage {
   city2: any = {
     name: 'London',
     favorited: false,
-    authorPic: 'http://bit.ly/2dMCa9y',
-    image: 'http://bit.ly/26lzMu0',
+    authorPic: 'https://bit.ly/2dMCa9y',
+    image: 'https://bit.ly/26lzMu0',
     favoriteCount: 10,
     comments: [1, 2, 3],
   };
@@ -41,8 +41,8 @@ export class SlideCarouselPage {
   city3: any = {
     name: 'Gramalote',
     favorited: false,
-    authorPic: 'http://bit.ly/2dMCa9y',
-    image: 'http://bit.ly/2dW9ZEl',
+    authorPic: 'https://bit.ly/2dMCa9y',
+    image: 'https://bit.ly/2dW9ZEl',
     favoriteCount: 10,
     comments: [1, 2, 3],
   };
@@ -50,8 +50,8 @@ export class SlideCarouselPage {
   city4: any = {
     name: 'Vladivostok',
     favorited: false,
-    authorPic: 'http://bit.ly/2dMCa9y',
-    image: 'http://bit.ly/2e0NFe4',
+    authorPic: 'https://bit.ly/2dMCa9y',
+    image: 'https://bit.ly/2e0NFe4',
     favoriteCount: 10,
     comments: [1, 2, 3],
   };
@@ -59,7 +59,7 @@ export class SlideCarouselPage {
   water1: any = {
     name: 'Water1',
     favorited: false,
-    authorPic: 'http://bit.ly/2dMCa9y',
+    authorPic: 'https://bit.ly/2dMCa9y',
     image: 'https://placeimg.com/600/400/nature',
     favoriteCount: 10,
     comments: [1, 2, 3],
@@ -68,7 +68,7 @@ export class SlideCarouselPage {
   water2: any = {
     name: 'Water2',
     favorited: false,
-    authorPic: 'http://bit.ly/2dMCa9y',
+    authorPic: 'https://bit.ly/2dMCa9y',
     image: 'https://placeimg.com/600/400/nature',
     favoriteCount: 5,
     comments: [1],
@@ -77,7 +77,7 @@ export class SlideCarouselPage {
   water3: any = {
     name: 'Water3',
     favorited: false,
-    authorPic: 'http://bit.ly/2dMCa9y',
+    authorPic: 'https://bit.ly/2dMCa9y',
     image: 'https://placeimg.com/600/400/nature',
     favoriteCount: 2,
     comments: [1],
@@ -86,7 +86,7 @@ export class SlideCarouselPage {
   water4: any = {
     name: 'Water4',
     favorited: false,
-    authorPic: 'http://bit.ly/2dMCa9y',
+    authorPic: 'https://bit.ly/2dMCa9y',
     image: 'https://placeimg.com/600/400/nature',
     favoriteCount: 8,
     comments: [1, 4, 2, 3],
@@ -95,7 +95,7 @@ export class SlideCarouselPage {
   water5: any = {
     name: 'Water5',
     favorited: false,
-    authorPic: 'http://bit.ly/2dMCa9y',
+    authorPic: 'https://bit.ly/2dMCa9y',
     image: 'https://placeimg.com/600/400/nature',
     favoriteCount: 4,
     comments: [1, 4, 2],
@@ -104,7 +104,7 @@ export class SlideCarouselPage {
   water6: any = {
     name: 'Water6',
     favorited: false,
-    authorPic: 'http://bit.ly/2dMCa9y',
+    authorPic: 'https://bit.ly/2dMCa9y',
     image: 'https://placeimg.com/600/400/nature',
     favoriteCount: 7,
     comments: [1, 4],
@@ -113,7 +113,7 @@ export class SlideCarouselPage {
   water7: any = {
     name: 'Water7',
     favorited: false,
-    authorPic: 'http://bit.ly/2dMCa9y',
+    authorPic: 'https://bit.ly/2dMCa9y',
     image: 'https://placeimg.com/600/400/nature',
     favoriteCount: 8,
     comments: [1, 4, 2, 3],
@@ -140,8 +140,8 @@ export class SlideCarouselPage {
     const newCity: any = {
       name: 'NewCity',
       favorited: false,
-      authorPic: 'http://bit.ly/2dMCa9y',
-      image: 'http://placekitten.com/g/900/550',
+      authorPic: 'https://bit.ly/2dMCa9y',
+      image: 'https://placekitten.com/g/900/550',
       favoriteCount: 0,
       comments: [],
     };

--- a/src/pages/slide/slide-photo-gallery/slide-photo-gallery.html
+++ b/src/pages/slide/slide-photo-gallery/slide-photo-gallery.html
@@ -7,16 +7,16 @@
   <!-- Swiper -->
   <div id="gallery-top" class="swiper-container gallery-top">
     <div class="swiper-wrapper">
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/1)"></div>
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/2)"></div>
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/3)"></div>
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/4)"></div>
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/5)"></div>
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/6)"></div>
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/7)"></div>
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/8)"></div>
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/9)"></div>
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/10)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/1)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/2)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/3)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/4)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/5)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/6)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/7)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/8)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/9)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/10)"></div>
     </div>
     <!-- Add Arrows -->
     <div class="swiper-button-next swiper-button-white"></div>
@@ -24,16 +24,16 @@
   </div>
   <div id="gallery-thumbs" class="swiper-container gallery-thumbs">
     <div class="swiper-wrapper">
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/1)"></div>
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/2)"></div>
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/3)"></div>
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/4)"></div>
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/5)"></div>
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/6)"></div>
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/7)"></div>
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/8)"></div>
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/9)"></div>
-      <div class="swiper-slide" style="background-image:url(http://lorempixel.com/1200/1200/nature/10)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/1)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/2)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/3)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/4)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/5)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/6)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/7)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/8)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/9)"></div>
+      <div class="swiper-slide" style="background-image:url(https://lorempixel.com/1200/1200/nature/10)"></div>
     </div>
   </div>
 </ion-content>

--- a/src/pages/slide/slide-photo-gallery/slide-photo-gallery.ts
+++ b/src/pages/slide/slide-photo-gallery/slide-photo-gallery.ts
@@ -33,25 +33,25 @@ export class SlidePhotoGalleryPage {
 
   slides = [
     {
-      imageUrl: 'http://lorempixel.com/1200/1200/nature/1',
+      imageUrl: 'https://lorempixel.com/1200/1200/nature/1',
     }, {
-      imageUrl: 'http://lorempixel.com/1200/1200/nature/2',
+      imageUrl: 'https://lorempixel.com/1200/1200/nature/2',
     }, {
-      imageUrl: 'http://lorempixel.com/1200/1200/nature/3',
+      imageUrl: 'https://lorempixel.com/1200/1200/nature/3',
     }, {
-      imageUrl: 'http://lorempixel.com/1200/1200/nature/4',
+      imageUrl: 'https://lorempixel.com/1200/1200/nature/4',
     }, {
-      imageUrl: 'http://lorempixel.com/1200/1200/nature/5',
+      imageUrl: 'https://lorempixel.com/1200/1200/nature/5',
     }, {
-      imageUrl: 'http://lorempixel.com/1200/1200/nature/6',
+      imageUrl: 'https://lorempixel.com/1200/1200/nature/6',
     }, {
-      imageUrl: 'http://lorempixel.com/1200/1200/nature/7',
+      imageUrl: 'https://lorempixel.com/1200/1200/nature/7',
     }, {
-      imageUrl: 'http://lorempixel.com/1200/1200/nature/8',
+      imageUrl: 'https://lorempixel.com/1200/1200/nature/8',
     }, {
-      imageUrl: 'http://lorempixel.com/1200/1200/nature/9',
+      imageUrl: 'https://lorempixel.com/1200/1200/nature/9',
     }, {
-      imageUrl: 'http://lorempixel.com/1200/1200/nature/10',
+      imageUrl: 'https://lorempixel.com/1200/1200/nature/10',
     },
   ];
 


### PR DESCRIPTION
While browsing the demo, I noticed that some assets could not be loaded because they were served over `http://`.

This pull request fixes most of those warnings/errors, except for the following 4 assets which are not available under `https://`:

http://weloveiconfonts.com/api/?family=zocial
http://web.arjentienkamp.com/codepen/tinder/delete.png
http://web.arjentienkamp.com/codepen/tinder/heart.png
http://web.arjentienkamp.com/codepen/tinder/info.png

You might want to consider including them in the repo or hosting them somewhere where they are accessible through https.

PS: Could you please add the link to your demo to the repo description at the top of the repo? It always takes me some seconds to find the link ;).