### PR TITLE
Fix Auto-Sizing 

### DIFF
--- a/src/app/app.imports.ts
+++ b/src/app/app.imports.ts
@@ -19,7 +19,6 @@ import { GoogleMaps } from '@ionic-native/google-maps';
 
 // Directives
 import { SlidingDrawer } from '../components/sliding-drawer/sliding-drawer';
-import { Autosize } from '../components/autosize/autosize';
 
 // Modules
 import { SwingModule } from 'angular2-swing';
@@ -52,5 +51,4 @@ export const PROVIDERS = [
 
 export const DIRECTIVES = [
   SlidingDrawer,
-  Autosize,
 ];

--- a/src/components/autosize/autosize.module.ts
+++ b/src/components/autosize/autosize.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { Autosize } from './autosize';
+
+@NgModule({
+  declarations: [Autosize],
+  exports: [Autosize]
+})
+export class AutoSizeModule {
+}

--- a/src/components/autosize/autosize.ts
+++ b/src/components/autosize/autosize.ts
@@ -1,4 +1,5 @@
 import { ElementRef, HostListener, Directive, OnInit } from '@angular/core';
+import { AlertService } from '../../providers/util/alert.service';
 
 @Directive({
   selector: 'ion-textarea[autosize]'

--- a/src/components/components.module.ts
+++ b/src/components/components.module.ts
@@ -7,6 +7,7 @@ import { TimerProgress } from './timer-progress/timer-progress';
 import { ExpandableHeader } from './expandable-header/expandable-header';
 import { FlashCardComponent } from './flash-card/flash-card';
 import { AccordionListComponent } from './accordion-list/accordion-list';
+import { Autosize } from './autosize/autosize';
 
 export const components = [
   Timer,
@@ -14,6 +15,7 @@ export const components = [
   ExpandableHeader,
   FlashCardComponent,
   AccordionListComponent,
+  Autosize
 ];
 
 @NgModule({

--- a/src/index.html
+++ b/src/index.html
@@ -36,9 +36,6 @@
   <!-- Ionic's root component and where the app will load -->
   <ion-app></ion-app>
 
-  <!-- cordova.js required for cordova apps -->
-  <script src="cordova.js"></script>
-
   <!-- The polyfills js is generated during the build process -->
   <script src="build/polyfills.js"></script>
 


### PR DESCRIPTION
 Auto sizing doesn't work for ionic 3 directives no longer being called due to lazy loading (might need to check SlidingDrawer as well) and fix throw due to cordova.js being declared twice in index